### PR TITLE
[Feat/#34] 공통 컴포넌트 구현 (다이얼로그)

### DIFF
--- a/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconDialog.kt
@@ -1,0 +1,16 @@
+package com.acon.core.designsystem.component.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun AconDialog(
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        content()
+    }
+}

--- a/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconOneButtonDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconOneButtonDialog.kt
@@ -1,0 +1,94 @@
+package com.acon.core.designsystem.component.dialog
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.acon.core.designsystem.R
+import com.acon.core.designsystem.component.button.AconFilledMediumButton
+import com.acon.core.designsystem.theme.AconTheme
+
+@Composable
+fun AconOneButtonDialog(
+    title: String,
+    content: String,
+    buttonContent: String,
+    @DrawableRes contentImage: Int,
+    onDismissRequest: () -> Unit,
+    onClickConfirm: () -> Unit,
+    isImageEnabled: Boolean = false,
+) {
+    AconDialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(AconTheme.color.Gray8)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if(isImageEnabled) {
+                Image(
+                    imageVector = ImageVector.vectorResource(contentImage),
+                    contentDescription = ""
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            Text(
+                text = title,
+                style = AconTheme.typography.head8_16_sb,
+                textAlign = TextAlign.Center,
+                color = AconTheme.color.White
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = content,
+                style = AconTheme.typography.body2_14_reg,
+                textAlign = TextAlign.Center,
+                color = AconTheme.color.Gray3
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AconFilledMediumButton(
+                text = buttonContent,
+                textStyle = AconTheme.typography.body2_14_reg,
+                enabledBackgroundColor = AconTheme.color.Gray5,
+                disabledBackgroundColor = AconTheme.color.Gray5,
+                onClick = onClickConfirm,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewAconOneButtonDialog() {
+    AconOneButtonDialog(
+        title = "인증 실패",
+        content = "인증 가능한 지역이 없어요.\n현재 위치로 인증을 진행할 수 있어요.",
+        buttonContent = "설정으로 가기",
+        contentImage = R.drawable.ic_review_g_40,
+        onDismissRequest = {},
+        onClickConfirm = {},
+        isImageEnabled = false
+    )
+}

--- a/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconTwoButtonDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/core/designsystem/component/dialog/AconTwoButtonDialog.kt
@@ -1,0 +1,123 @@
+package com.acon.core.designsystem.component.dialog
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.acon.core.designsystem.R
+import com.acon.core.designsystem.component.button.AconFilledMediumButton
+import com.acon.core.designsystem.component.button.AconOutlinedLargeButton
+import com.acon.core.designsystem.theme.AconTheme
+
+@Composable
+fun AconTwoButtonDialog(
+    title: String,
+    content: String,
+    leftButtonContent: String,
+    rightButtonContent: String,
+    @DrawableRes contentImage: Int,
+    onDismissRequest: () -> Unit,
+    onClickLeft: () -> Unit,
+    onClickRight: () -> Unit,
+    isImageEnabled: Boolean = false,
+) {
+    AconDialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(AconTheme.color.Gray8)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if(isImageEnabled) {
+                Image(
+                    imageVector = ImageVector.vectorResource(contentImage),
+                    contentDescription = ""
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            Text(
+                text = title,
+                style = AconTheme.typography.head8_16_sb,
+                textAlign = TextAlign.Center,
+                color = AconTheme.color.White
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = content,
+                style = AconTheme.typography.body2_14_reg,
+                textAlign = TextAlign.Center,
+                color = AconTheme.color.Gray3
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                AconOutlinedLargeButton(
+                    text = leftButtonContent,
+                    enabledBorderColor = AconTheme.color.Gray5,
+                    enabledBackgroundColor = AconTheme.color.Gray8,
+                    disabledBorderColor = AconTheme.color.Gray5,
+                    disabledBackgroundColor = AconTheme.color.Gray5,
+                    onClick = onClickLeft,
+                    textColor = AconTheme.color.Gray3,
+                    textStyle = AconTheme.typography.body2_14_reg,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.width(7.dp))
+
+                AconFilledMediumButton(
+                    text = rightButtonContent,
+                    textStyle = AconTheme.typography.body2_14_reg,
+                    enabledBackgroundColor = AconTheme.color.Gray5,
+                    disabledBackgroundColor = AconTheme.color.Gray5,
+                    onClick = onClickRight,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewAconTwoButtonDialog() {
+    AconTwoButtonDialog(
+        title = "인증 실패",
+        content = "인증 가능한 지역이 없어요.\n현재 위치로 인증을 진행할 수 있어요.",
+        leftButtonContent = "취소",
+        rightButtonContent = "확인",
+        contentImage = R.drawable.ic_review_g_40,
+        onDismissRequest = {},
+        onClickLeft = { },
+        onClickRight = { },
+        isImageEnabled = false
+    )
+}


### PR DESCRIPTION
## *🧨 Issue*
- closed #34

## *💻 Work Description*
- 버튼 1개 다이얼로그 (이미지 유/무)
- 버튼 2개 다이얼로그 (이미지 유/무) 

## *📸 Screenshot*
|           버튼 1개 이미지  O           |              버튼 1개 이미지  X               |
|:-----------------------------------------------------------------------------:|:-----------------------------------------------------------------------------:|
| <img width="500" src="https://github.com/user-attachments/assets/ba591981-2130-4d0e-bab5-2915bd667ee7"/> | <img width="500" src="https://github.com/user-attachments/assets/baa325e1-c82e-401d-b7dd-584841a130d5"/> |

|             버튼 2개 이미지  O                |              버튼 2개 이미지  X               |
|:-----------------------------------------------------------------------------:|:-----------------------------------------------------------------------------:|
| <img width="500" src="https://github.com/user-attachments/assets/0c42d5e0-c5da-411c-95fa-5a8f8f7302b6"/> | <img width="500" src="https://github.com/user-attachments/assets/17c4e4b5-333b-498b-90d4-bdbc2cb06cbd"/> |

